### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ dependencies = [
 [[package]]
 name = "rtic"
 version = "2.0.0-alpha.0"
-source = "git+https://github.com/rtic-rs/cortex-m-rtic.git?branch=rticv2#6c73c3452a1924c713973b2262d4b09838426e02"
+source = "git+https://github.com/rtic-rs/cortex-m-rtic.git?branch=rticv2#32b537aef63a2f69c5abc83b0af3fd88205ce0ce"
 dependencies = [
  "atomic-polyfill",
  "bare-metal 1.0.0",
@@ -806,7 +806,7 @@ dependencies = [
 [[package]]
 name = "rtic-common"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/rtic-rs/cortex-m-rtic.git?branch=rticv2#6c73c3452a1924c713973b2262d4b09838426e02"
+source = "git+https://github.com/rtic-rs/cortex-m-rtic.git?branch=rticv2#32b537aef63a2f69c5abc83b0af3fd88205ce0ce"
 dependencies = [
  "critical-section",
 ]
@@ -820,7 +820,7 @@ checksum = "d9369355b04d06a3780ec0f51ea2d225624db777acbc60abd8ca4832da5c1a42"
 [[package]]
 name = "rtic-macros"
 version = "2.0.0-alpha.0"
-source = "git+https://github.com/rtic-rs/cortex-m-rtic.git?branch=rticv2#6c73c3452a1924c713973b2262d4b09838426e02"
+source = "git+https://github.com/rtic-rs/cortex-m-rtic.git?branch=rticv2#32b537aef63a2f69c5abc83b0af3fd88205ce0ce"
 dependencies = [
  "indexmap",
  "proc-macro-error",
@@ -832,10 +832,11 @@ dependencies = [
 [[package]]
 name = "rtic-monotonics"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/rtic-rs/cortex-m-rtic.git?branch=rticv2#6c73c3452a1924c713973b2262d4b09838426e02"
+source = "git+https://github.com/rtic-rs/cortex-m-rtic.git?branch=rticv2#32b537aef63a2f69c5abc83b0af3fd88205ce0ce"
 dependencies = [
  "atomic-polyfill",
  "cfg-if",
+ "cortex-m",
  "fugit",
  "rp2040-pac",
  "rtic-time",
@@ -844,7 +845,7 @@ dependencies = [
 [[package]]
 name = "rtic-time"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/rtic-rs/cortex-m-rtic.git?branch=rticv2#6c73c3452a1924c713973b2262d4b09838426e02"
+source = "git+https://github.com/rtic-rs/cortex-m-rtic.git?branch=rticv2#32b537aef63a2f69c5abc83b0af3fd88205ce0ce"
 dependencies = [
  "critical-section",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ bitflags = "1.3.2"
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 # cortex-m-rtic = "1.1.3"
 rtic = { git = "https://github.com/rtic-rs/cortex-m-rtic.git", branch = "rticv2", features= ["thumbv6-backend"]}
-rtic-monotonics = { git = "https://github.com/rtic-rs/cortex-m-rtic.git", branch = "rticv2", features = ["rp2040"]}
+rtic-monotonics = { git = "https://github.com/rtic-rs/cortex-m-rtic.git", branch = "rticv2", features = ["rp2040", "cortex_m_systick"]}
 defmt = { version = "0.3.2", features = ["encoding-rzcobs"] }
 defmt-rtt = "0.4.0"
 embedded-hal = { version = "0.2.5", features = ["unproven"] }


### PR DESCRIPTION
Fixes the following error:

```
    Updating git repository `https://github.com/rtic-rs/cortex-m-rtic.git`
error: failed to get `rtic` as a dependency of package `pico-probe v0.1.0 (/home/jan/tmp/rusty-probe-firmware)`

Caused by:
  failed to load source for dependency `rtic`

Caused by:
  Unable to update https://github.com/rtic-rs/cortex-m-rtic.git?branch=rticv2#6c73c345

Caused by:
  object not found - no match for id (6c73c3452a1924c713973b2262d4b09838426e02); class=Odb (9); code=NotFound (-3)
```

It looks like the version in Cargo.lock is no longer available from github, for some reason?