### PR TITLE
`defmt` logs over USB-serial

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a785a543aea40f5e4e2e93bb2655d31bc21bb391fff65697150973e383f16bb"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.6",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "ascii-canvas"
@@ -68,6 +89,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
 
 [[package]]
+name = "bbqueue"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3baa8859d1a4c7411039a75c0599a4640ef1c9a8fc811e4325b00e6cfe0a55"
+dependencies = [
+ "cortex-m 0.6.7",
+ "defmt",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +139,19 @@ checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
  "unicode-width",
+]
+
+[[package]]
+name = "cortex-m"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9075300b07c6a56263b9b582c214d0ff037b00d45ec9fde1cc711490c56f1bb9"
+dependencies = [
+ "aligned",
+ "bare-metal 0.2.5",
+ "bitfield",
+ "cortex-m 0.7.7",
+ "volatile-register",
 ]
 
 [[package]]
@@ -191,6 +235,17 @@ checksum = "d3a0ae7494d9bff013d7b89471f4c424356a71e9752e0c78abe7e6c608a16bb3"
 dependencies = [
  "bitflags",
  "defmt-macros",
+]
+
+[[package]]
+name = "defmt-bbq"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c937dfd3aa385c0ceb497b513f23f9dea75c884dc12ac18cae2ccb7675c7a327"
+dependencies = [
+ "bbqueue",
+ "cortex-m 0.7.7",
+ "defmt",
 ]
 
 [[package]]
@@ -318,6 +373,34 @@ name = "gcd"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
+
+[[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -502,7 +585,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ab1f00eac22bd18f8e5cae9555f2820b3a0c166b5b556ee3e203746ea6dcf3a"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.7",
  "defmt",
 ]
 
@@ -564,10 +647,12 @@ checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 name = "pico-probe"
 version = "0.1.0"
 dependencies = [
+ "bbqueue",
  "bitflags",
- "cortex-m",
+ "cortex-m 0.7.7",
  "dap-rs",
  "defmt",
+ "defmt-bbq",
  "defmt-rtt",
  "embedded-hal",
  "git-version",
@@ -751,7 +836,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecf1b975581f0cac465247c464e7d2b8d93c7a5fceb4eb13b7b8517f4f85f6d"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.7",
  "critical-section",
  "embedded-hal",
  "fugit",
@@ -785,7 +870,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9192cafbb40d717c9e0ddf767aaf9c69fee1b4e48d22ed853b57b11f6d9f3d7e"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.7.7",
  "cortex-m-rt",
  "vcell",
 ]
@@ -797,7 +882,7 @@ source = "git+https://github.com/rtic-rs/rtic.git?branch=master#3a0e2ac92438c818
 dependencies = [
  "atomic-polyfill",
  "bare-metal 1.0.0",
- "cortex-m",
+ "cortex-m 0.7.7",
  "critical-section",
  "rtic-core",
  "rtic-macros",
@@ -836,7 +921,7 @@ source = "git+https://github.com/rtic-rs/rtic.git?branch=master#3a0e2ac92438c818
 dependencies = [
  "atomic-polyfill",
  "cfg-if",
- "cortex-m",
+ "cortex-m 0.7.7",
  "fugit",
  "rp2040-pac",
  "rtic-time",
@@ -899,6 +984,12 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "string_cache"
@@ -983,6 +1074,12 @@ checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 rtic = { git = "https://github.com/rtic-rs/rtic.git", branch = "master", features= ["thumbv6-backend"] }
 rtic-monotonics = { git = "https://github.com/rtic-rs/rtic.git", branch = "master", features = ["rp2040", "cortex-m-systick"] }
 defmt = { version = "0.3.2", features = ["encoding-rzcobs"] }
-defmt-rtt = "0.4.0"
 embedded-hal = { version = "0.2.5", features = ["unproven"] }
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 replace_with = { version = "0.1.7", default-features = false, features = ["panic_abort"] }
@@ -24,6 +23,16 @@ pio = "0.2.1"
 # If you're not going to use a Board Support Package you'll need these:
 rp2040-hal = { version = "0.7.0", features = ["rt"] }
 rp2040-boot2 = "0.2.1"
+
+defmt-rtt = { version = "0.4.0", optional = true }
+defmt-bbq = { version = "0.1.0", optional = true }
+# We don't need bbqueue directly, but we need to activate the
+# thumbv6 feature on it so it will compile.
+bbqueue = { version = "0.5", features = ["thumbv6"], optional = true }
+
+[features]
+default = [ "defmt-rtt" ]
+defmt-bbq = ["dep:defmt-bbq", "dep:bbqueue"]
 
 # cargo build/run
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,30 @@ elf2uf2-rs target/thumbv6m-none-eabi/release/app app
 
 Start the Pico in bootloader mode and drop the `app.uf2` file to it, done! 
 
+## Running with `defmt` logs without debugger
+
+If you don't have a debugger/programmer to program or debug your rusty-probe with, you can still run the probe and see the defmt logs it prints.
+
+To do so, start the probe with the bootloader enabled by powering it on while holding
+the button pressed. Mount the resulting block device.
+
+Then, perform the following steps:
+
+```console
+# Install elf2uf2-rs and defmt-print (you only need to do this once)
+cargo install elf2uf2-rs defmt-print
+
+# Build the ELF file with the desired level of logging and the
+# correct defmt transport.
+DEFMT_LOG=debug cargo build --release --bin app  \
+        --no-default-features                    \
+        --features defmt-bbq
+
+# Flash the ELF, attach to the serial port, and print the defmt logs
+elf2uf2-rs -s -d target/thumbv6m-none-eabi/release/app \
+    | defmt-print -e ./target/thumbv6m-none-eabi/release/app
+```
+
 ## TODO
 
 - [x] Move SWD impl to PIO

--- a/src/bin/app.rs
+++ b/src/bin/app.rs
@@ -61,19 +61,15 @@ mod app {
 
             defmt::debug!("Tracking Target VCC at {} mV", target_vcc_mv);
 
-            if target_vcc_mv > 2500 {
-                cx.local.leds.green(true);
-                cx.local.leds.red(false);
-                cx.local.leds.blue(false);
+            let (r, g, b) = if target_vcc_mv > 2500 {
+                (false, true, false)
             } else if target_vcc_mv > 1500 {
-                cx.local.leds.green(false);
-                cx.local.leds.red(true);
-                cx.local.leds.blue(false);
+                (true, false, false)
             } else {
-                cx.local.leds.green(false);
-                cx.local.leds.red(false);
-                cx.local.leds.blue(true);
-            }
+                (false, false, true)
+            };
+
+            cx.local.leds.rgb(r, g, b);
 
             Timer::delay(100.millis()).await;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,13 @@
 #![no_std]
 
 use core::sync::atomic::{AtomicUsize, Ordering};
-use defmt_rtt as _;
 use panic_probe as _;
+
+#[cfg(feature = "defmt-rtt")]
+use defmt_rtt as _;
+
+#[cfg(feature = "defmt-bbq")]
+use defmt_bbq as _;
 
 pub mod dap;
 pub mod device_signature;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
 
-use core::sync::atomic::{AtomicUsize, Ordering};
 use panic_probe as _;
 
 #[cfg(feature = "defmt-rtt")]
@@ -9,6 +8,9 @@ use defmt_rtt as _;
 #[cfg(feature = "defmt-bbq")]
 use defmt_bbq as _;
 
+use rp2040_hal::timer::Instant;
+use rtic_monotonics::{rp2040::Timer, Monotonic};
+
 pub mod dap;
 pub mod device_signature;
 pub mod pio;
@@ -16,11 +18,7 @@ pub mod setup;
 pub mod systick_delay;
 pub mod usb;
 
-defmt::timestamp! {"{=u64}", {
-    static COUNT: AtomicUsize = AtomicUsize::new(0);
-    // NOTE(no-CAS) `timestamps` runs with interrupts disabled
-    let n = COUNT.load(Ordering::Relaxed);
-    COUNT.store(n + 1, Ordering::Relaxed);
-    n as u64
+defmt::timestamp! {"{=u64:us}", {
+    Timer::now().checked_duration_since(Instant::from_ticks(0)).map(|i| i.ticks()).unwrap_or(0)
 }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -140,13 +140,13 @@ pub fn setup(
     let mut dir_ck = pins.gpio19;
     let reset = pins.gpio9;
 
-    let tdi = pins.gpio17;
-    let dir_tdi = pins.gpio23;
+    let _tdi = pins.gpio17;
+    let _dir_tdi = pins.gpio23;
 
-    let vcp_rx = pins.gpio21;
-    let vcp_tx = pins.gpio20;
-    let dir_vcp_rx = pins.gpio25;
-    let dir_vcp_tx = pins.gpio24;
+    let _vcp_rx = pins.gpio21;
+    let _vcp_tx = pins.gpio20;
+    let _dir_vcp_rx = pins.gpio25;
+    let _dir_vcp_tx = pins.gpio24;
 
     // High speed IO
     io.set_drive_strength(OutputDriveStrength::TwelveMilliAmps);

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -69,7 +69,14 @@ pub fn setup(
         &mut resets,
     )));
 
-    let probe_usb = ProbeUsb::new(&usb_bus);
+    #[cfg(feature = "defmt-bbq")]
+    let consumer = defmt_bbq::init().ok().unwrap();
+
+    let probe_usb = ProbeUsb::new(
+        &usb_bus,
+        #[cfg(feature = "defmt-bbq")]
+        consumer,
+    );
 
     let sio = Sio::new(pac.SIO);
     let pins = Pins::new(pac.IO_BANK0, pac.PADS_BANK0, sio.gpio_bank0, &mut resets);

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -228,6 +228,12 @@ impl BoardLeds {
     pub fn toggle_blue(&mut self) {
         self.blue.toggle().ok();
     }
+
+    pub fn rgb(&mut self, r: bool, g: bool, b: bool) {
+        self.red(r);
+        self.green(g);
+        self.blue(b);
+    }
 }
 
 pub struct TargetVccReader {


### PR DESCRIPTION
Sending defmt logs over the USB serial :man_dancing: :rocket: 

The logs are likely come out in big blocks with the current instructions due to buffering of `stdout` between `elf2uf2-rs` and `defmt-print`. To fix it, we can either wait until https://github.com/JoNil/elf2uf2-rs/pull/18 is merged, include [this linux-specific workaround](https://unix.stackexchange.com/a/25378) in the README, or add some sort of additional serial reader.