### PR TITLE
Led manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "embedded-dma"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "994f7e5b5cb23521c22304927195f236813053eb9c065dd2226a32ba64695446"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "embedded-hal"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,6 +661,7 @@ dependencies = [
  "rp2040-boot2",
  "rp2040-hal",
  "rtic",
+ "rtic-common",
  "rtic-monotonics",
  "usb-device",
  "usbd-serial",
@@ -821,12 +831,13 @@ dependencies = [
 
 [[package]]
 name = "rp2040-hal"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecf1b975581f0cac465247c464e7d2b8d93c7a5fceb4eb13b7b8517f4f85f6d"
+checksum = "bd64ea14218eaa350e5cf1023b7a84c267f092e4a64b69129dc460e53412bed8"
 dependencies = [
  "cortex-m 0.7.7",
  "critical-section",
+ "embedded-dma",
  "embedded-hal",
  "fugit",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,6 +653,7 @@ dependencies = [
  "defmt",
  "defmt-brtt",
  "embedded-hal",
+ "futures-util",
  "git-version",
  "panic-probe",
  "pio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ dap-rs = { git = "https://github.com/korken89/dap-rs.git", features = ["defmt"] 
 git-version = "0.3.5"
 pio-proc = "0.2.1"
 pio = "0.2.1"
+futures-util = { version = "0.3.27", default-features = false }
 
 # If you're not going to use a Board Support Package you'll need these:
 rp2040-hal = { version = "0.8.0", features = ["rt"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ bitflags = "1.3.2"
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 rtic = { git = "https://github.com/rtic-rs/rtic.git", branch = "master", features= ["thumbv6-backend"] }
 rtic-monotonics = { git = "https://github.com/rtic-rs/rtic.git", branch = "master", features = ["rp2040", "cortex-m-systick"] }
+rtic-common = { git = "https://github.com/rtic-rs/rtic.git", branch = "master" }
 defmt = { version = "=0.3.2", features = ["encoding-rzcobs"] }
 embedded-hal = { version = "0.2.5", features = ["unproven"] }
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
@@ -21,7 +22,7 @@ pio-proc = "0.2.1"
 pio = "0.2.1"
 
 # If you're not going to use a Board Support Package you'll need these:
-rp2040-hal = { version = "0.7.0", features = ["rt"] }
+rp2040-hal = { version = "0.8.0", features = ["rt"] }
 rp2040-boot2 = "0.2.1"
 
 defmt-brtt = { version = "0.1.0", default-features = false }

--- a/src/bin/app.rs
+++ b/src/bin/app.rs
@@ -7,7 +7,7 @@ use pico_probe as _;
 #[rtic::app(device = rp2040_hal::pac, dispatchers = [XIP_IRQ, CLOCKS_IRQ])]
 mod app {
     use core::mem::MaybeUninit;
-    use pico_probe::setup::*;
+    use pico_probe::{leds::BoardLeds, setup::*};
     use rp2040_hal::usb::UsbBus;
     use usb_device::class_prelude::*;
 

--- a/src/bin/test-io.rs
+++ b/src/bin/test-io.rs
@@ -8,6 +8,7 @@ use pico_probe as _;
 mod app {
     use core::mem::MaybeUninit;
     use embedded_hal::digital::v2::OutputPin;
+    use pico_probe::leds::BoardLeds;
     use pico_probe::setup::*;
     use rp2040_hal::gpio::PinState;
     use rp2040_hal::usb::UsbBus;
@@ -163,19 +164,19 @@ mod app {
     #[task(local = [leds])]
     async fn led_test(cx: led_test::Context) {
         loop {
-            cx.local.leds.red(true);
+            cx.local.leds.set_red(true);
             Systick::delay(100.millis()).await;
-            cx.local.leds.red(false);
-            Systick::delay(100.millis()).await;
-
-            cx.local.leds.green(true);
-            Systick::delay(100.millis()).await;
-            cx.local.leds.green(false);
+            cx.local.leds.set_red(false);
             Systick::delay(100.millis()).await;
 
-            cx.local.leds.blue(true);
+            cx.local.leds.set_green(true);
             Systick::delay(100.millis()).await;
-            cx.local.leds.blue(false);
+            cx.local.leds.set_green(false);
+            Systick::delay(100.millis()).await;
+
+            cx.local.leds.set_blue(true);
+            Systick::delay(100.millis()).await;
+            cx.local.leds.set_blue(false);
             Systick::delay(100.millis()).await;
         }
     }

--- a/src/dap.rs
+++ b/src/dap.rs
@@ -207,15 +207,6 @@ impl swj::Dependencies<Swd, Jtag> for Context {
     }
 }
 
-#[derive(Debug, defmt::Format)]
-pub struct Leds {}
-
-impl dap::DapLeds for Leds {
-    fn react_to_host_status(&mut self, _host_status: dap::HostStatus) {
-        trace!("Running LEDs react to host status");
-    }
-}
-
 pub struct Jtag(Context);
 
 impl From<Jtag> for Context {
@@ -522,6 +513,7 @@ pub fn create_dap(
     dir_swclk: DynPin,
     cpu_frequency: u32,
     delay: &'static Delay,
+    leds: crate::leds::HostStatusToken,
 ) -> crate::setup::DapHandler {
     let context = Context::from_pins(
         swdio,
@@ -532,7 +524,6 @@ pub fn create_dap(
         cpu_frequency,
         delay,
     );
-    let leds = Leds {};
     let wait = Wait::new(delay);
     let swo = None;
 

--- a/src/leds.rs
+++ b/src/leds.rs
@@ -92,31 +92,22 @@ pub enum Vtarget {
     Voltage3V3,
 }
 
+use core::sync::atomic::{AtomicU8, Ordering};
 use core::task::Poll;
-use core::{
-    marker::PhantomData,
-    sync::atomic::{AtomicU8, Ordering},
-};
 use rtic_common::waker_registration::CriticalSectionWakerRegistration;
 
-pub struct HostStatusToken {
-    // To make sure no one else can construct it
-    _field: PhantomData<()>,
-}
+/// A token that can be used to update the DAP Host
+/// status.
+#[derive(Debug, Clone, Copy)]
+pub struct HostStatusToken;
 
 pub struct LedManager {
     leds: BoardLeds,
-    dap_leds: Option<HostStatusToken>,
 }
 
 impl LedManager {
     pub fn new(leds: BoardLeds) -> Self {
-        Self {
-            leds,
-            dap_leds: Some(HostStatusToken {
-                _field: Default::default(),
-            }),
-        }
+        Self { leds }
     }
 
     fn vtarget_storage() -> &'static AtomicU8 {
@@ -165,8 +156,8 @@ impl LedManager {
         Self::waker().wake();
     }
 
-    pub fn host_status_token(&mut self) -> Option<HostStatusToken> {
-        self.dap_leds.take()
+    pub fn host_status_token(&mut self) -> HostStatusToken {
+        HostStatusToken
     }
 
     pub fn current_vtarget() -> Option<Vtarget> {

--- a/src/leds.rs
+++ b/src/leds.rs
@@ -139,6 +139,20 @@ pub enum Vtarget {
     Voltage3V3,
 }
 
+/// A struct that manages the onboard LEDs
+///
+/// Current color scheme:
+/// * Host not connected
+///     * No Vtarget detected: Red
+///     * 1.8V Vtarget detected: Pink
+///     * 3.3V Vtarget detected: White
+/// * Host Connected: Yellow
+/// * Not running: blue
+/// * Running: green
+///
+/// After each state change a short delay is introduced to ensure that
+/// the color can be noticed, unless it updates to a new state other than
+/// Host not connected.
 pub struct LedManager {
     leds: BoardLeds,
 }

--- a/src/leds.rs
+++ b/src/leds.rs
@@ -1,4 +1,5 @@
-use embedded_hal::digital::v2::{OutputPin, ToggleableOutputPin};
+use dap_rs::dap::{DapLeds, HostStatus};
+use embedded_hal::digital::v2::OutputPin;
 use rp2040_hal::gpio::{bank0::*, Pin, PushPullOutput};
 
 pub struct BoardLeds {
@@ -18,32 +19,244 @@ impl BoardLeds {
         me
     }
 
-    pub fn red(&mut self, level: bool) {
+    fn set_red(&mut self, level: bool) {
         self.red.set_state((!level).into()).ok();
     }
 
-    pub fn toggle_red(&mut self) {
-        self.red.toggle().ok();
-    }
-
-    pub fn green(&mut self, level: bool) {
+    fn set_green(&mut self, level: bool) {
         self.green.set_state((!level).into()).ok();
     }
 
-    pub fn toggle_green(&mut self) {
-        self.green.toggle().ok();
-    }
-
-    pub fn blue(&mut self, level: bool) {
+    fn set_blue(&mut self, level: bool) {
         self.blue.set_state((!level).into()).ok();
-    }
-    pub fn toggle_blue(&mut self) {
-        self.blue.toggle().ok();
     }
 
     pub fn rgb(&mut self, r: bool, g: bool, b: bool) {
-        self.red(r);
-        self.green(g);
-        self.blue(b);
+        self.set_red(r);
+        self.set_green(g);
+        self.set_blue(b);
+    }
+
+    pub fn red(&mut self) {
+        self.rgb(true, false, false);
+    }
+
+    /// R + G = yellow
+    pub fn yellow(&mut self) {
+        self.rgb(true, true, false);
+    }
+
+    pub fn green(&mut self) {
+        self.rgb(false, true, false);
+    }
+
+    // G + B = light blue
+    pub fn light_blue(&mut self) {
+        self.rgb(false, true, true);
+    }
+
+    pub fn blue(&mut self) {
+        self.rgb(false, false, true);
+    }
+
+    // R + B = purple-ish
+    pub fn pink(&mut self) {
+        self.rgb(true, false, true);
+    }
+
+    // R + G + B = white/purple
+    pub fn white(&mut self) {
+        self.rgb(true, true, true);
+    }
+
+    /// Off
+    pub fn off(&mut self) {
+        self.rgb(false, false, false);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, defmt::Format)]
+pub enum Vtarget {
+    Voltage1V8,
+    Voltage3V3,
+}
+
+use core::task::Poll;
+use core::{
+    marker::PhantomData,
+    sync::atomic::{AtomicU8, Ordering},
+};
+use rtic_common::waker_registration::CriticalSectionWakerRegistration;
+
+pub struct HostStatusToken {
+    // To make sure no one else can construct it
+    _field: PhantomData<()>,
+}
+
+pub struct LedManager {
+    leds: BoardLeds,
+    dap_leds: Option<HostStatusToken>,
+}
+
+impl LedManager {
+    pub fn new(leds: BoardLeds) -> Self {
+        Self {
+            leds,
+            dap_leds: Some(HostStatusToken {
+                _field: Default::default(),
+            }),
+        }
+    }
+
+    fn vtarget_storage() -> &'static AtomicU8 {
+        static VTARGET_STORAGE: AtomicU8 = AtomicU8::new(0);
+        &VTARGET_STORAGE
+    }
+
+    fn waker() -> &'static CriticalSectionWakerRegistration {
+        static REG: CriticalSectionWakerRegistration = CriticalSectionWakerRegistration::new();
+        &REG
+    }
+
+    fn host_status_storage() -> &'static AtomicU8 {
+        static HOST_STATUS_STORAGE: AtomicU8 = AtomicU8::new(0);
+        &HOST_STATUS_STORAGE
+    }
+
+    fn current_host_status() -> Option<HostStatus> {
+        let value = Self::host_status_storage().load(Ordering::Relaxed);
+
+        if value == 1 {
+            Some(HostStatus::Connected(false))
+        } else if value == 2 {
+            Some(HostStatus::Connected(true))
+        } else if value == 3 {
+            Some(HostStatus::Running(false))
+        } else if value == 4 {
+            Some(HostStatus::Running(true))
+        } else {
+            None
+        }
+    }
+
+    pub fn set_host_status(host_status: HostStatus) {
+        let value = match host_status {
+            HostStatus::Connected(false) => 1,
+            HostStatus::Connected(true) => 2,
+            HostStatus::Running(false) => 3,
+            HostStatus::Running(true) => 4,
+        };
+
+        Self::host_status_storage().store(value, Ordering::Relaxed);
+
+        // Updating the host status is always a state transition,
+        // so we want to wake the waker.
+        Self::waker().wake();
+    }
+
+    pub fn host_status_token(&mut self) -> Option<HostStatusToken> {
+        self.dap_leds.take()
+    }
+
+    pub fn current_vtarget() -> Option<Vtarget> {
+        let value = Self::vtarget_storage().load(Ordering::Relaxed);
+
+        if value == 1 {
+            Some(Vtarget::Voltage1V8)
+        } else if value == 2 {
+            Some(Vtarget::Voltage3V3)
+        } else {
+            None
+        }
+    }
+
+    pub fn set_current_vtarget(vtarget: Option<Vtarget>) {
+        let new_value = if vtarget == Some(Vtarget::Voltage1V8) {
+            1
+        } else if vtarget == Some(Vtarget::Voltage3V3) {
+            2
+        } else {
+            0
+        };
+
+        let current_vtarget = Self::current_vtarget();
+        Self::vtarget_storage().store(new_value, Ordering::Relaxed);
+
+        // If Vtarget has changed, we may want to make a change to the LEDs
+        if current_vtarget != vtarget {
+            Self::waker().wake();
+        }
+    }
+
+    fn set(&mut self) -> bool {
+        let current_vtarget = Self::current_vtarget();
+        let current_host_status = Self::current_host_status();
+
+        let is_activity = match (current_vtarget, current_host_status) {
+            (Some(current_vtarget), None)
+            | (Some(current_vtarget), Some(HostStatus::Connected(false))) => {
+                match current_vtarget {
+                    Vtarget::Voltage1V8 => self.leds.yellow(),
+                    Vtarget::Voltage3V3 => self.leds.white(),
+                }
+                false
+            }
+            (_, Some(HostStatus::Connected(true))) => {
+                self.leds.blue();
+                true
+            }
+            (_, Some(HostStatus::Running(false))) => {
+                self.leds.light_blue();
+                true
+            }
+            (_, Some(HostStatus::Running(true))) => {
+                self.leds.green();
+                true
+            }
+            (None, _) => {
+                self.leds.red();
+                false
+            }
+        };
+
+        is_activity
+    }
+
+    pub async fn update(&mut self) {
+        let is_activity = self.set();
+        if is_activity {
+            // Wait for a little bit so the status can actually be seen.
+            use rtic_monotonics::rp2040::{ExtU64, Timer};
+
+            Timer::delay(50.millis()).await;
+        }
+    }
+
+    pub async fn run(&mut self) -> ! {
+        loop {
+            let mut polled = false;
+
+            // Set the LEDs to whatever the current state is.
+            self.set();
+
+            core::future::poll_fn(|ctx| {
+                if !polled {
+                    polled = true;
+                    Self::waker().register(ctx.waker());
+                    Poll::Pending
+                } else {
+                    Poll::Ready(())
+                }
+            })
+            .await;
+
+            self.update().await;
+        }
+    }
+}
+
+impl DapLeds for HostStatusToken {
+    fn react_to_host_status(&mut self, host_status: HostStatus) {
+        LedManager::set_host_status(host_status);
     }
 }

--- a/src/leds.rs
+++ b/src/leds.rs
@@ -1,6 +1,11 @@
+use core::marker::PhantomData;
+use core::sync::atomic::{AtomicU8, Ordering};
+use core::task::Poll;
+
 use dap_rs::dap::DapLeds;
 use embedded_hal::digital::v2::OutputPin;
 use rp2040_hal::gpio::{bank0::*, Pin, PushPullOutput};
+use rtic_common::waker_registration::CriticalSectionWakerRegistration;
 
 #[derive(Debug, Clone, Copy, PartialEq, defmt::Format)]
 enum HostStatus {
@@ -106,11 +111,6 @@ pub enum Vtarget {
     Voltage1V8,
     Voltage3V3,
 }
-
-use core::marker::PhantomData;
-use core::sync::atomic::{AtomicU8, Ordering};
-use core::task::Poll;
-use rtic_common::waker_registration::CriticalSectionWakerRegistration;
 
 pub struct LedManager {
     leds: BoardLeds,
@@ -258,6 +258,7 @@ impl LedManager {
             // Wait for an update to occur
             core::future::poll_fn(|ctx| {
                 Self::waker().register(ctx.waker());
+
                 let new_vtarget = Self::current_vtarget();
                 let new_host_status = Self::current_host_status();
 

--- a/src/leds.rs
+++ b/src/leds.rs
@@ -198,17 +198,17 @@ impl LedManager {
             (Some(current_vtarget), None)
             | (Some(current_vtarget), Some(HostStatus::Connected(false))) => {
                 match current_vtarget {
-                    Vtarget::Voltage1V8 => self.leds.yellow(),
+                    Vtarget::Voltage1V8 => self.leds.pink(),
                     Vtarget::Voltage3V3 => self.leds.white(),
                 }
                 false
             }
             (_, Some(HostStatus::Connected(true))) => {
-                self.leds.blue();
+                self.leds.yellow();
                 true
             }
             (_, Some(HostStatus::Running(false))) => {
-                self.leds.light_blue();
+                self.leds.blue();
                 true
             }
             (_, Some(HostStatus::Running(true))) => {

--- a/src/leds.rs
+++ b/src/leds.rs
@@ -1,0 +1,49 @@
+use embedded_hal::digital::v2::{OutputPin, ToggleableOutputPin};
+use rp2040_hal::gpio::{bank0::*, Pin, PushPullOutput};
+
+pub struct BoardLeds {
+    green: Pin<Gpio27, PushPullOutput>,
+    red: Pin<Gpio28, PushPullOutput>,
+    blue: Pin<Gpio29, PushPullOutput>,
+}
+
+impl BoardLeds {
+    pub fn new(
+        red: Pin<Gpio28, PushPullOutput>,
+        green: Pin<Gpio27, PushPullOutput>,
+        blue: Pin<Gpio29, PushPullOutput>,
+    ) -> Self {
+        let mut me = Self { red, green, blue };
+        me.rgb(false, false, false);
+        me
+    }
+
+    pub fn red(&mut self, level: bool) {
+        self.red.set_state((!level).into()).ok();
+    }
+
+    pub fn toggle_red(&mut self) {
+        self.red.toggle().ok();
+    }
+
+    pub fn green(&mut self, level: bool) {
+        self.green.set_state((!level).into()).ok();
+    }
+
+    pub fn toggle_green(&mut self) {
+        self.green.toggle().ok();
+    }
+
+    pub fn blue(&mut self, level: bool) {
+        self.blue.set_state((!level).into()).ok();
+    }
+    pub fn toggle_blue(&mut self) {
+        self.blue.toggle().ok();
+    }
+
+    pub fn rgb(&mut self, r: bool, g: bool, b: bool) {
+        self.red(r);
+        self.green(g);
+        self.blue(b);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ use rtic_monotonics::{rp2040::Timer, Monotonic};
 
 pub mod dap;
 pub mod device_signature;
+pub mod leds;
 pub mod pio;
 pub mod setup;
 pub mod systick_delay;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -175,7 +175,7 @@ pub fn setup(
 
     let board_leds = BoardLeds::new(led_red, led_green, led_blue);
     let mut led_manager = LedManager::new(board_leds);
-    let host_status_token = led_manager.host_status_token().unwrap();
+    let host_status_token = led_manager.host_status_token();
 
     let dap_hander = dap::create_dap(
         git_version,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,10 +1,10 @@
 use crate::dap::{Context, Jtag, Leds, Swd, Swo, Wait};
+use crate::leds::BoardLeds;
 use crate::systick_delay::Delay;
 use crate::{dap, usb::ProbeUsb};
 use core::mem::MaybeUninit;
 use embedded_hal::adc::OneShot;
 use embedded_hal::digital::v2::OutputPin;
-use embedded_hal::digital::v2::ToggleableOutputPin;
 use embedded_hal::PwmPin;
 use rp2040_hal::{
     clocks::init_clocks_and_plls,
@@ -188,11 +188,7 @@ pub fn setup(
     rp2040::Timer::start(pac.TIMER, &mut resets, timer_token);
 
     (
-        BoardLeds {
-            red: led_red,
-            green: led_green,
-            blue: led_blue,
-        },
+        BoardLeds::new(led_red, led_green, led_blue),
         probe_usb,
         dap_hander,
         adc,
@@ -209,43 +205,6 @@ pub struct AllIOs {
     pub reset: Pin<Gpio9, PushPullOutput>,
     pub vcp_rx: Pin<Gpio21, PushPullOutput>,
     pub vcp_tx: Pin<Gpio20, PushPullOutput>,
-}
-
-pub struct BoardLeds {
-    pub green: Pin<Gpio27, PushPullOutput>,
-    pub red: Pin<Gpio28, PushPullOutput>,
-    pub blue: Pin<Gpio29, PushPullOutput>,
-}
-
-impl BoardLeds {
-    pub fn red(&mut self, level: bool) {
-        self.red.set_state((!level).into()).ok();
-    }
-
-    pub fn toggle_red(&mut self) {
-        self.red.toggle().ok();
-    }
-
-    pub fn green(&mut self, level: bool) {
-        self.green.set_state((!level).into()).ok();
-    }
-
-    pub fn toggle_green(&mut self) {
-        self.green.toggle().ok();
-    }
-
-    pub fn blue(&mut self, level: bool) {
-        self.blue.set_state((!level).into()).ok();
-    }
-    pub fn toggle_blue(&mut self) {
-        self.blue.toggle().ok();
-    }
-
-    pub fn rgb(&mut self, r: bool, g: bool, b: bool) {
-        self.red(r);
-        self.green(g);
-        self.blue(b);
-    }
 }
 
 pub struct TargetVccReader {


### PR DESCRIPTION
Adds an LED manager that reflects the DAP/Vtarget status.

The delay thing is there to ensure that even very short events can be observed by holding the LED at a different color for a short while.

I'm not convinced of the color scheme yet, but I think it is OK for now.

It's documented [here](https://github.com/probe-rs/rusty-probe-firmware/pull/8/files#diff-581db1c4fb974b8b65b1e54e42289afa08da7f232bdd0a5efd858038120dee21R144), and should probably be added to the README once it's finalized.

Observing the `HostStatus::Running` LEDs is a bit hard ATM because `probe-rs` doesn't support it yet (but I've opened a [pull request](https://github.com/probe-rs/probe-rs/pull/1588) to see if there is reasonable way to add support for it)