### PR TITLE
Add flip-link install to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This firmware implements an CMSIS-DAP v1 and v2 compatible probe.
 You can build the project and generate a `.uf2` file as follows:
 
 ```console
-# Install elf2uf2-rs
-cargo install elf2uf2-rs
+# Install elf2uf2-rs and flip-link (you only need to do this once)
+cargo install elf2uf2-rs flip-link
 
 # Build the ELF without logging
 DEFMT_LOG=off cargo build --release --bin app
@@ -28,8 +28,8 @@ To do so, start the probe in the USB bootloader by powering it on while holding 
 Then, perform the following steps:
 
 ```console
-# Install elf2uf2-rs and defmt-print (you only need to do this once)
-cargo install elf2uf2-rs defmt-print
+# Install elf2uf2-rs, flip-link, and defmt-print (you only need to do this once)
+cargo install elf2uf2-rs flip-link defmt-print
 
 # Build the binary with the desired level of logging, and run
 # it using `xtask`


### PR DESCRIPTION
Added instructions to install flip-link as it is needed to build rusty-probe-firmware.

Without flip-link:

```
error: linker `flip-link` not found
  |
  = note: No such file or directory (os error 2)

error: could not compile `pico-probe` (bin "app") due to 1 previous error

```