### PR TITLE
Tiding on latest working nightly rustc 2024-06-12.

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-06-12"
 components = [ "rust-src", "rustfmt", "llvm-tools-preview" ]
 targets = [ "thumbv6m-none-eabi", "thumbv7m-none-eabi" ]


### PR DESCRIPTION
### Related Issues : https://github.com/probe-rs/rusty-probe-firmware/issues/15

Current rust embedded eco system has problem since rustc nightly 2024-06-13.
This would be related with this report https://github.com/embassy-rs/static-cell/issues/16
Checked some of rust embedded project pass compile on 2024-06-12 include this repo.