### PR TITLE
added gnddetect feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,9 @@ defmt-brtt = { version = "0.1.0", default-features = false }
 bbqueue = { version = "0.5", features = ["thumbv6"], optional = true }
 
 [features]
-default = [ "defmt-brtt/rtt" ]
+default = [ "defmt-brtt/rtt", "gnddetect" ]
 defmt-bbq = ["defmt-brtt/bbq", "dep:bbqueue"]
+gnddetect = []
 usb-serial-reboot = []
 
 # cargo build/run

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -225,7 +225,10 @@ pub struct TargetPhysicallyConnected {
 impl TargetPhysicallyConnected {
     /// This checks for the target being connected via the GND detect pin.
     pub fn target_detected(&self) -> bool {
-        matches!(self.pin.is_low(), Ok(true))
+        #[cfg(feature = "gnddetect")]
+        return matches!(self.pin.is_low(), Ok(true));
+        #[cfg(not(feature = "gnddetect"))]
+        return true;
     }
 }
 


### PR DESCRIPTION
Here's a way to disable ground detect at compile time.

Changes:
- Added _gnddetect_ feature which enables ground detect when used.

Testing:
- Default feature build, ground detect works, led is red when the debugger starts, and turns white when a device supporting ground detect is plugged in.
- Firmware without the _gnddetect_ feature, led is white when the debugger starts, and is immediately able to debug an RPi Pico.

Related Issues:
- Addresses #18 