### PR TITLE
Swd sequence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,8 +217,8 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "dap-rs"
-version = "0.2.0"
-source = "git+https://github.com/Grapple-Systems/dap-rs.git?branch=add-swd-sequence#a958131771e0a70c89885268f799f4f4c24eda25"
+version = "0.1.0"
+source = "git+https://github.com/probe-rs/dap-rs.git?branch=master#48286e45410a0fe39e86399e335fc9b506b7135e"
 dependencies = [
  "bitflags 1.3.2",
  "defmt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,8 +217,8 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "dap-rs"
-version = "0.1.0"
-source = "git+https://github.com/probe-rs/dap-rs.git?branch=master#d0ff8298ca32b150143d242dda03f3ff11ac9ae0"
+version = "0.2.0"
+source = "git+https://github.com/Grapple-Systems/dap-rs.git?branch=add-swd-sequence#a958131771e0a70c89885268f799f4f4c24eda25"
 dependencies = [
  "bitflags 1.3.2",
  "defmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ embedded-hal-02 = { package = "embedded-hal", version = "0.2.7", features = ["un
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 replace_with = { version = "0.1.7", default-features = false, features = ["panic_abort"] }
 usbd-serial = "0.2.0"
-dap-rs = { git = "https://github.com/Grapple-Systems/dap-rs.git", branch = "add-swd-sequence", features = ["defmt"] }
+dap-rs = { git = "https://github.com/probe-rs/dap-rs.git", branch = "master", features = ["defmt"] }
 git-version = "0.3.5"
 pio-proc = "0.2.1"
 pio = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ embedded-hal-02 = { package = "embedded-hal", version = "0.2.7", features = ["un
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 replace_with = { version = "0.1.7", default-features = false, features = ["panic_abort"] }
 usbd-serial = "0.2.0"
-dap-rs = { git = "https://github.com/probe-rs/dap-rs.git", branch = "master", features = ["defmt"] }
+dap-rs = { git = "https://github.com/Grapple-Systems/dap-rs.git", branch = "add-swd-sequence", features = ["defmt"] }
 git-version = "0.3.5"
 pio-proc = "0.2.1"
 pio = "0.2.1"


### PR DESCRIPTION
Implement the swd sequence command trait functions in the bitbanged swd driver.

Will need to run a `cargo update` after https://github.com/probe-rs/dap-rs/pull/4 gets merged to get the updated dap-rs.

Changes:
- Implemented write_sequence and read_sequence.

Testing:
- Successfully ran an openocd session using this [branch](https://github.com/jonathanherbstgrapple/rusty-probe-firmware/tree/swd-sequence-working)

Related Tickets:
- Closes #24 
- Depends on https://github.com/probe-rs/dap-rs/issues/3