### PR TITLE
Fix update instructions to use picotool instead of elf2uf2-rs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,11 +1,11 @@
 # Choose a default "cargo run" tool.
 # probe-run is recommended if you have a debugger
-# elf2uf2-rs loads firmware over USB when the rp2040 is in boot mode
+# picotool loads firmware over USB when the rp2040 is in boot mode
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 # runner = "probe-run --chip RP2040 --probe 3c004b001051383439393134"
 # runner = "probe-run --chip RP2040 --probe dc6168968f3b812eef4014"
 # runner = "probe-run --chip RP2040 --probe dc61cd078f667031ef4014"
-# runner = "elf2uf2-rs -d"
+# runner = "picotool load -x -t elf"
 
 # This runner allows you to log & restart the Rusty Probe using
 # nothing but a USB connection.

--- a/README.md
+++ b/README.md
@@ -4,20 +4,31 @@ This firmware implements an CMSIS-DAP v1 and v2 compatible probe.
 
 ## Building
 
-You can build the project and generate a `.uf2` file as follows:
+First, make sure you have `picotool` available on your system. 
+Instructions for installing it can be found [here](https://github.com/raspberrypi/picotool).
+
+You can then build the project and generate a `.uf2` file as follows:
 
 ```console
-# Install elf2uf2-rs and flip-link (you only need to do this once)
-cargo install elf2uf2-rs flip-link
+# Install flip-link (you only need to do this once)
+cargo install flip-link
 
 # Build the ELF without logging
 DEFMT_LOG=off cargo build --release --bin app
 
 # Generate .uf2 file
-elf2uf2-rs target/thumbv6m-none-eabi/release/app app
+picotool uf2 convert -t elf target/thumbv6m-none-eabi/release/app app.uf2
 ```
 
 Start the RP2040 in bootloader mode and drop the `app.uf2` file to it, done! 
+
+Alternatively, you can use the provided `picotool load` command to skip the conversion step.
+Plug the `rusty-probe` into your computer while holding the button pressed (to enter `bootsel` mode) and run:
+
+```
+# Directly load the binary onto the device (instead of generating a .uf2 file step above)
+picotool load -x -t elf target/thumbv6m-none-eabi/release/app
+```
 
 ## Running with `defmt` logs without debugger
 


### PR DESCRIPTION
Fixes the instructions for building/flashing new firmware using `picotool` instead of `elf2uf2-rs`.

Also update `.cargo/config.toml` to provide a `picotool load...` runner.

No change here on the "Running with `defmt` logs without debugger" section, which also seems to be using `elf2uf2-rs` and I don't think is working either.