### PR TITLE
add nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake .

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ target/
 !.vscode/extensions.json
 !.vscode/settings.json
 
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,83 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1763966396,
+        "narHash": "sha256-6eeL1YPcY1MV3DDStIDIdy/zZCDKgHdkCmsrLJFiZf0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5ae3b07d8d6527c42f17c876e404993199144b6a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1763347184,
+        "narHash": "sha256-6QH8hpCYJxifvyHEYg+Da0BotUn03BwLIvYo3JAxuqQ=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "08895cce80433978d5bfd668efa41c5e24578cbd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "ref": "stable",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay/stable";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = inputs:
+    with inputs;
+      flake-utils.lib.eachDefaultSystem (
+        system: let
+          overlays = [(import rust-overlay)];
+          pkgs = import nixpkgs {
+            inherit system overlays;
+          };
+        in {
+          devShells = {
+            default = with pkgs;
+              mkShell {
+                buildInputs = [
+                  (rust-bin.stable.latest.default.override {
+                    extensions = [
+                      "llvm-tools"
+                      "rust-src"
+                    ];
+                    targets = [
+                      "thumbv6m-none-eabi"
+                    ];
+                  })
+                  cargo-nextest
+                  cargo-binutils
+                  cargo-udeps
+                  cargo-vet
+                  cargo-about
+                  cargo-release
+
+                  rust-analyzer
+                  rustfmt
+
+                  openocd
+                  gcc-arm-embedded
+
+                  elf2uf2-rs
+                  flip-link
+                  probe-rs-tools
+                  # If the dependencies need system libs, you usually need pkg-config + the lib
+                ];
+              };
+          };
+
+          formatter = nixpkgs.legacyPackages.${system}.alejandra;
+        }
+      );
+}


### PR DESCRIPTION
Nix flake makes it easier to develop on NixOS and doesn't impact anyone else. Although it's possible to use the same nix flake on other distros by installing `nix`. This can be used manually with `nix develop` to enter a dev shell with all the required dependencies.

The nix flake is declarative config that tells nix which dependencies are required to build the firmware. I was able to build and update my rusty-probe on NixOS using the dependencies provided by this flake.

Direnv config makes it easier for people using direnv. Once the user approves the config on their machine (after reading the script), it automatically loads the flake devshell when you enter the directory. This is really convenient for quick development.